### PR TITLE
Suggested build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+FROM debian:9
+
+# To update, see https://github.com/madler/zlib/releases
+ENV ZLIB_SRC https://github.com/madler/zlib/archive/v1.2.11.tar.gz
+ENV ZLIB_SHA512 104c62ed1228b5f1199bc037081861576900eb0697a226cafa62a35c4c890b5cb46622e399f9aad82ee5dfb475bae26ae75e2bd6da3d261361b1c8b996970faf
+
+
+RUN apt-get -qq update && \
+  apt-get -y --no-install-recommends install build-essential libbz2-dev curl ca-certificates
+WORKDIR /usr/src
+
+RUN echo "$ZLIB_SHA512  zlib.tar.gz" > zlib.tar.gz.sha512
+RUN curl -sS -L --fail $ZLIB_SRC > zlib.tar.gz && \
+    sha512sum -c zlib.tar.gz.sha512 && \
+    tar zxfv zlib.tar.gz && \
+    mv zlib-* zlib
+
+# Compile zlib and install to /usr/local
+
+WORKDIR /usr/src/zlib
+RUN ./configure && make && make install
+
+# We'll need the *.o from blast and infback9 later
+WORKDIR /usr/src/zlib/contrib/blast
+RUN gcc -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -I .  -I ../../ -c -Wall -Werror -fpic blast.c
+WORKDIR /usr/src/zlib/contrib/infback9
+# gcc -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -c -o 
+RUN gcc  -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -I .  -I ../../ -c -Wall -Werror -fpic infback9.c inftree9.c
+
+
+WORKDIR /usr/src/
+
+####
+# Add sunzip source code (modify below if additional files needed)
+COPY sunzip.c  /usr/src/sunzip/
+###
+# OR - uncomment below to use latest sunzip release:
+# To update, see https://github.com/madler/sunzip/releases
+#ENV SUNZIP_SRC https://github.com/madler/sunzip/archive/v0.4.tar.gz
+#ENV SUNZIP_SHA512 85331549755181704592a74e9533ec74f474017fe8891801df0416865323e8bc5b3540e2b0b276e50037b7e57e70bb6b702741136e0aae4c6658c7ca1a3e27a6
+#RUN echo "$SUNZIP_SHA512  sunzip.tar.gz" > sunzip.tar.gz.sha512
+#RUN curl -sS -L --fail $SUNZIP_SRC > sunzip.tar.gz && \
+#    sha512sum -c sunzip.tar.gz.sha512 && \
+#    tar zxfv sunzip.tar.gz && \
+#    mv sunzip-* sunzip
+####
+
+# Compile sunzip binary
+WORKDIR /usr/src/sunzip
+RUN gcc  -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN \
+  -I ../zlib/contrib/infback9 \
+  -I ../zlib/contrib/blast \
+  -I ../zlib/contrib/bz \
+  -I /usr/local/include \
+  -L /usr/local/lib \
+  -Wl,-rpath=/usr/local/lib \
+  -o sunzip \
+  ../zlib/zutil.o \
+  ../zlib/contrib/blast/blast.o \
+  ../zlib/contrib/infback9/infback9.o  \
+  ../zlib/contrib/infback9/inftree9.o  \
+  sunzip.c -lbz2 -lz
+
+# Test it actually works
+RUN curl -L https://github.com/madler/sunzip/archive/master.zip | ./sunzip -t
+# We'll "install"
+RUN cp sunzip /usr/local/bin
+
+
+# Make a smaller base image to only
+# include our binaries
+FROM debian:9
+COPY --from=0 /usr/local/ /usr/local/
+
+WORKDIR /data
+VOLUME /data
+CMD ["/usr/local/bin/sunzip"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ before finally downloading and compiling `sunzip.c`.
 
 Modify the URLs below to use different versions.
 
-```
+```bash
 apt-get -y install build-essential libbz2-dev curl ca-certificates
 cd /tmp
 
@@ -92,6 +92,34 @@ usage: ... | sunzip [-t] [-o] [-p x] [-q[q]] [dir]
 	-q: quiet -- display summary info and errors only
 	-qq: really quiet -- display errors only
 	dir: subdirectory to create files in (if writing)
+```
+
+Docker
+------
+
+If you have [Docker](https://www.docker.com/), you can build a 
+Debian-compatible binary using:
+
+    docker build -t madler/sunzip .
+
+The docker image has the `/data` volume as default working 
+directory where files will be extracted. 
+
+The below example extract from a ZIP URL and extracts it into
+the host `/tmp/1` exposed as `/data`. 
+
+
+    URL=https://github.com/madler/sunzip/archive/master.zip
+    curl --fail -L $URL | docker run -i -v /tmp/1:/data madler/sunzip
+
+**Tip**: To avoid extracted files owned by `root` make sure the mapped 
+directory exists and specify the Docker option `--user` with your UID:
+
+```bash
+    mkdir /tmp/5
+    URL=https://github.com/madler/sunzip/archive/master.zip
+    curl --fail -L $URL | docker run --user `id -u` -i -v /tmp/5:/data madler/sunzip
+    ls -al /tmp/5
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -28,12 +28,73 @@ Compile and link with zlib, infback9.c and inftree9.c (found in zlib's contrib
 directory), blast.c (also in contrib), and libbz2. blast.c from zlib 1.2.9 or
 later must be used.
 
-Test
-----
 
-`cat any.zip | sunzip`
+### Example: Debian/Ubuntu
+
+The below example compiles a recent [zlib](https://github.com/madler/zlib) that is 
+installed to `/usr/local/lib` - then `contrib/blast` and `contrib/infback9`
+before finally downloading and compiling `sunzip.c`. 
+
+Modify the URLs below to use different versions.
+
+```
+apt-get -y install build-essential libbz2-dev curl ca-certificates
+cd /tmp
+
+curl -L -o zlib.tar.gz https://github.com/madler/zlib/archive/v1.2.11.tar.gz
+tar zxfv zlib.tar.gz
+mv zlib-* zlib && cd zlib
+./configure && make
+sudo make install
+
+cd contrib/blast
+gcc -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -I .  -I ../../ -c -Wall -Werror -fpic blast.c
+cd ../infback9
+gcc  -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -I .  -I ../../ -c -Wall -Werror -fpic infback9.c inftree9.c
+
+cd /tmp
+curl -L -o sunzip.tar.gz https://github.com/madler/sunzip/archive/v0.4.tar.gz
+tar zxfv sunzip.tar.gz
+cd sunzip-*
+gcc  -O3 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN \
+  -I ../zlib/contrib/infback9 \
+  -I ../zlib/contrib/blast \
+  -I ../zlib/contrib/bz \
+  -I /usr/local/include \
+  -L /usr/local/lib \
+  -Wl,-rpath=/usr/local/lib \
+  -o sunzip \
+  ../zlib/zutil.o \
+  ../zlib/contrib/blast/blast.o \
+  ../zlib/contrib/infback9/infback9.o  \
+  ../zlib/contrib/infback9/inftree9.o  \
+  sunzip.c -lbz2 -lz
+
+sudo cp sunzip /usr/local/bin
+sunzip
+```
+
+Usage
+-----
+
+    cat any.zip | sunzip
+
+For help, run `sunzip` without arguments on a terminal:
+
+```
+sunzip 0.4, streaming unzip by Mark Adler
+usage: ... | sunzip [-t] [-o] [-p x] [-q[q]] [dir]
+       sunzip [-t] [-o] [-p x] [-q[q]] [dir] < infile.zip
+
+	-t: test -- don't write files
+	-o: overwrite existing files
+	-p x: replace parent reference .. with this character
+	-q: quiet -- display summary info and errors only
+	-qq: really quiet -- display errors only
+	dir: subdirectory to create files in (if writing)
+```
 
 License
 -------
 
-This code is under the zlib license, permitting free commercial use.
+This code is under the [zlib license](sunzip.c), permitting free commercial use.


### PR DESCRIPTION
My attempt to address issue #1 

See Markdown rendering on https://github.com/stain/sunzip/blob/build-instructions/README.md

Obviously build instructions will vary alot by OS, but I thought an example for Debian/Ubuntu might be helpful, in particular as `contrib/blast` and  `contrib/infback9` are not compiled (or even included) in their outdated zlib.

I probably got half the `gcc` options wrong.. please help! :) Perhaps it should compile `libz` as a static library to avoid the `-rpath` trick? Or should one simply compile the contribs against the older system `zlib1g-dev` (1.2.11 in Ubuntu 18:04, 1.2.8 in Debian 9)?
 

I also added a `Dockerfile` to create a Docker image (to test my instructions). The instructions to build that suggest `madler/sunzip` as Docker image name. You could add an automated build on https://cloud.docker.com/ which would pick up this `Dockerfile` and re-build on any changes here. To test it today try my test-build `stain/sunzip`.
