### PR TITLE
Add -l list option to only list filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Synopsis
 _sunzip_ is a streaming unzip utility. It will read a .zip file from stdin and
 decompress its contents into the current directory. Command line options allow
 specifying a different destination directory, overwriting existing files
-(normally prevented), and testing the contents of .zip file instead of writing
-the decompressed files.
+(normally prevented), and testing or listing the contents of .zip file instead
+of writing the decompressed files.
 
 _sunzip_ can decompress methods 0 (stored), 8 (deflated), 9 (Deflate64), 10
 (DCL imploded), and 12 (bzip2). _sunzip_ handles Zip64 .zip files. It does not
@@ -28,12 +28,44 @@ Compile and link with zlib, infback9.c and inftree9.c (found in zlib's contrib
 directory), blast.c (also in contrib), and libbz2. blast.c from zlib 1.2.9 or
 later must be used.
 
-Test
-----
 
-`cat any.zip | sunzip`
+
+Usage
+-----
+
+    cat any.zip | sunzip
+
+For help, run `sunzip` without arguments on a terminal:
+
+```
+sunzip 0.4, streaming unzip by Mark Adler
+usage: ... | sunzip [-t] [-o] [-p x] [-q[q]] [dir]
+       sunzip [-t] [-o] [-p x] [-q[q]] [dir] < infile.zip
+
+	-t: test -- don't write files
+	-l: list zip filenames -- don't write files
+	-o: overwrite existing files
+	-p x: replace parent reference .. with this character
+	-q: quiet -- display summary info and errors only
+	-qq: really quiet -- display errors only
+	dir: subdirectory to create files in (if writing)
+```
+
+`sunzip` will decompress to the current directory unless `dir` is specified.
+
+The `sunzip -t` option will test decompression and verify crc checksums
+without writing any files to disk.
+
+The `sunzip -l` option is equivalent to `-t -q -q`, but instead
+of testing decompression will only print the file and directory
+names as they are encountered in the stream. Note that file
+names from the local file headers are less reliable than the
+end-of-file TOC that would otherwise be used, and may
+include duplicates, deleted and encrypted files.
+
+
 
 License
 -------
 
-This code is under the zlib license, permitting free commercial use.
+This code is under the [zlib license](sunzip.c), permitting free commercial use.

--- a/sunzip.c
+++ b/sunzip.c
@@ -1254,6 +1254,8 @@ local void sunzip(int file, int quiet, int write, int over, int list)
             if (flag & 0xf7f0U)
                 bye("unknown zip header flags set");
             method = get2(in);          /* compression method */
+            if ((flag & 8) && list)
+                bye("cannot handle deferred lengths without decompressing (try -t)");
             if ((flag & 8) && method != 8 && method != 9 && method != 12)
                 bye("cannot handle deferred lengths for pre-deflate methods");
             acc = mod = dos2time(get4(in));     /* file date/time */


### PR DESCRIPTION
The `sunzip -l` option is equivalent to `-t -q -q`, but instead of testing decompression will only print the file and directory names as they are encountered in the stream. 

Note that file names from the local file headers are less reliable than the end-of-file TOC that would otherwise be used, and may include duplicates, deleted and encrypted files.

Output is silent so that STDOUT can be used with `grep` etc. Filenames are expressed as they will be written for the local OS (discuss!)

Here is example usage on a 1.9 GB zip file:

    curl -sS -L 'https://zenodo.org/record/2838898/files/rnaseqwf_0.5.0_mac.zip?download=1' |  sunzip -l

