### PR TITLE
Add "cli callback" for streaming output

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Synopsis
 
 _sunzip_ is a streaming unzip utility. It will read a .zip file from stdin and
 decompress its contents into the current directory. Command line options allow
-specifying a different destination directory, overwriting existing files
-(normally prevented), and testing the contents of .zip file instead of writing
-the decompressed files.
+specifying a different destination directory; overwriting existing files
+(normally prevented); streaming each file to specified program and saving its
+stdout instead of original file; testing the contents of .zip file instead 
+of writing the decompressed files.
 
 _sunzip_ can decompress methods 0 (stored), 8 (deflated), 9 (Deflate64), 10
 (DCL imploded), and 12 (bzip2). _sunzip_ handles Zip64 .zip files. It does not

--- a/sunzip.c
+++ b/sunzip.c
@@ -67,7 +67,12 @@
                      Add zlib license
    0.5   6 Jan 2021  Add -r option to retain temporary files in the event of
                      an error.
-
+   0.6  xxxxxxxxxxx  Add -c option that pipes each extracted file to specified program
+                     and save its stdout on disk.
+                     Add -j option for limiting count of concurent instances of program
+                     spawned by -c
+                     NOTE: this patch is currently unix specific (tested on linux and freebsd)
+                     Probably won't even compile on windows (I don't know if it did before)
  */
 
 /* Notes:

--- a/sunzip.c
+++ b/sunzip.c
@@ -1148,6 +1148,12 @@ int spawn_callback(struct cb_prog* cb, char* writepath)
         bye("pipe creation failed: %s", strerror(errno));
     }
 
+    if(cb->jobs == cb->job_limit) { // too much childs, wait for one
+        if(wait(NULL) == -1) bye("wait error: %s", strerror(errno)); 
+    } else {
+        ++cb->jobs;
+    }
+
     pid_t pid = fork();
     if(pid == -1) {
         bye("fork failed: %s", strerror(errno));
@@ -1175,11 +1181,6 @@ int spawn_callback(struct cb_prog* cb, char* writepath)
         }
     }
     else { // we are in parent
-        if((cb->jobs + 1) >= cb->job_limit) { // too much childs, wait for one
-            if(wait(NULL) == -1) bye("wait error: %s", strerror(errno)); 
-        } else {
-            ++cb->jobs;
-        }
         if(close(pipefd[READ_PIPE_END])) {
             bye("close error: %s", strerror(errno));
         }

--- a/sunzip.c
+++ b/sunzip.c
@@ -1136,7 +1136,7 @@ struct cb_prog
 #define WRITE_PIPE_END 1
 
 /* spawn program and redirect it's stdout to specified file. Return pipe connected to its stdin */
-int spawn_callback(struct cb_prog* cb, char* writepath)
+local int spawn_callback(struct cb_prog* cb, char* writepath)
 {
     // optimization ideas:
     // - find best place for checking job_limit (and invoking wait())


### PR DESCRIPTION
Add `-c cmd [cmd_arg ...] ;` option which, for each extracted file will spawn supplied program, supply decompressed file to its stdin and save its stdout instead of original file.
Add `-j n` option, for specifing count of concurent instances of spawned callbacks

It allows for downloading, unziping and processing files without storing originals on disk

For example:
- download, unzip and convert pictures from archive to webp, non-picture-files are "destroyed": `curl "https://dd.b.pvp.net/latest/set1-lite-en_us.zip" | sunzip -j 4 -c cwebp -quiet -m 5 -o - -- - \;`
- [Same, but more elaborate](https://gist.github.com/gizlu/e27d80a5ceff4ea98647a7daa4bf7ac3/aeb37f29f2dd09418b89b05abb13b81f8d047bfe#file-rundeck_db_build-sh-L53-L69=)
- compute checksum of every file in archive: `sunzip -c md5sum - \; -j 2 < archive.zip` (very likely useless, but nice for testing)

Problems with this patch:
- sunzip will keep running even if program returns non-zero exit code. Rationale for that is that callbacks often fail with non-zero status if suplied unrecognized file. Maybe I should add flag for not ignoring child's exit code when it is not a problem?
- It is unix specific. It won't even compile on windows (has it before?). It can be made optional feature disabled on not posix (easy), or ported
- Cleanup after childs, in case of sunzip failure, is done in quite wishful manner - we assume that single SIGTERM will simply kill them. It should be easily fixable, see comments in `bye()` implementation
- We don't handle any timeouts. Should we?

I done this for fun and don't have any particular use case for this (actually, I had, but this was another useless project done for fun), thus i don't have much motivation for polishing this, but I can try if you would be willing to merge this

